### PR TITLE
Use eslint binary from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node cyc_entry.js",
     "test": "mocha --recursive test/",
-    "lint": "./node_modules/eslint/bin/eslint.js .",
-    "lint-fix": "./node_modules/eslint/bin/eslint.js --fix ."
+    "lint": "eslint .",
+    "lint-fix": "eslint --fix ."
   },
   "dependencies": {
     "body-parser": "^1.15.1",
@@ -34,5 +34,5 @@
     ,
     "url": "https://github.com/StayWokeOrg/general-congress-hotline"
   },
-  "license": "MIT" 
+  "license": "MIT"
 }


### PR DESCRIPTION
### What?

* Replaces eslint references in favor binaries from node_modules
* Removes trailing whitespace after license key

### Why?

npm auto-magically appends binaries from dependencies to `PATH`.  We do not have to use relative paths in run scripts

See: https://docs.npmjs.com/misc/scripts#path