### PR TITLE
Return multiple representatives for zip codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+data/raw
+venv
+
 lib-cov
 *.seed
 *.log

--- a/controllers/congress.js
+++ b/controllers/congress.js
@@ -3,6 +3,7 @@ const request = require('request');
 
 const Callee = require('./callee').Callee;
 const dc = require('./dc');
+const lookupRep = require('../data/zip-to-rep-lookup.js');
 
 const HOUSE_API_URL = `https://api.civil.services/v1/house/?apikey=${process.env.CAMPAIGNZERO_KEY || process.env.CIVIL_SERVICES_KEY}`;
 const SENATE_API_URL = `https://api.civil.services/v1/senate/?apikey=${process.env.CAMPAIGNZERO_KEY || process.env.CIVIL_SERVICES_KEY}`;
@@ -10,22 +11,34 @@ const SENATE_API_URL = `https://api.civil.services/v1/senate/?apikey=${process.e
 const cachedZipLookups = {};
 
 function getSenators(zip, cb) {
-  getPeople(HOUSE_API_URL, zip, 'senate', cb);
+  getPeopleFromApi(HOUSE_API_URL, zip, 'senate', cb);
 }
 
 function getHouseReps(zip, cb) {
-  getPeople(HOUSE_API_URL, zip, 'house', cb);
+  const callees = lookupRep(zip).map((personObj) => {
+    // Map API response to generic callee model.
+    return new Callee(personObj.first_name, personObj.last_name,
+                      personObj.phone, 'house');
+  });
+  cb(callees);
 }
 
 function getSenatorsAndHouseReps(zip, cb) {
   async.parallel([
     function(done) {
-      getPeople(HOUSE_API_URL, zip, 'house', function(results) {
+      // TODO(ian): Reactivate the below once Civil Services API returns all
+      // representatives for a given zipcode.
+      /*
+      getPeopleFromApi(HOUSE_API_URL, zip, 'house', function(results) {
+        done(null, results);
+      });
+     */
+      getHouseReps(zip, function(results) {
         done(null, results);
       });
     },
     function(done) {
-      getPeople(SENATE_API_URL, zip, 'senate', function(results) {
+      getPeopleFromApi(SENATE_API_URL, zip, 'senate', function(results) {
         done(null, results);
       });
     },
@@ -40,7 +53,7 @@ function getSenatorsAndHouseReps(zip, cb) {
   });
 }
 
-function getPeople(baseUrl, zip, chamber, cb) {
+function getPeopleFromApi(baseUrl, zip, chamber, cb) {
   const cacheKey = `${zip}___${chamber}`;
   if (cachedZipLookups[cacheKey]) {
     cb(cachedZipLookups[cacheKey]);

--- a/data/generate_zip_to_rep.sh
+++ b/data/generate_zip_to_rep.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+pushd `dirname $0` &>/dev/null
+
+mkdir -p raw
+
+wget -O raw/zip_to_cd.csv 'https://raw.githubusercontent.com/OpenSourceActivismTech/us_zipcodes_congress/master/zccd.csv'
+wget -O raw/legislators.csv 'https://theunitedstates.io/congress-legislators/legislators-current.csv'
+python merge.py
+
+popd &>/dev/null

--- a/data/merge.py
+++ b/data/merge.py
@@ -1,0 +1,28 @@
+import csv
+import json
+
+from collections import defaultdict
+
+state_cd_to_zips = defaultdict(lambda: defaultdict(list))
+with open('./raw/zip_to_cd.csv') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        state_cd_to_zips[row['state_abbr']][row['cd']].append(row['zcta'])
+
+zip_to_legislator = defaultdict(list)
+with open('./raw/legislators.csv') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        if not row['district']:
+            continue
+        zipcodes = state_cd_to_zips[row['state']][row['district']]
+        for zipcode in zipcodes:
+            zip_to_legislator[zipcode].append({
+                'first_name': row['first_name'],
+                'last_name': row['last_name'],
+                'full_name': '%s %s' % (row['first_name'], row['last_name']),
+                'phone': row['phone'],
+            })
+
+with open('zip_to_reps.json', 'w') as f:
+    f.write(json.dumps(zip_to_legislator, indent=2))

--- a/data/zip-to-rep-lookup.js
+++ b/data/zip-to-rep-lookup.js
@@ -1,0 +1,6 @@
+const zipToReps = require('./zip_to_reps.json');
+
+module.exports = function zipToRepsLookup(zip) {
+  // Takes a zip, returns a list of representatives.
+  return zipToReps[zip + ''] || [];
+}

--- a/test/phone.js
+++ b/test/phone.js
@@ -60,11 +60,24 @@ describe('phone', () => {
     it('retries on bad zip code', (done) => {
       request(app)
         .post('/call_house')
+        .send({ Digits: '42424' })
         .expect(200)
         .expect((res) => {
           assert.notEqual(
             res.text.indexOf('switchboard'), -1,
             'redirects to switchboard');
+        })
+        .end(done);
+    });
+
+    it('returns multiple house reps', (done) => {
+      request(app)
+        .post('/call_house')
+        .send({ Digits: '94043' })
+        .expect(200)
+        .expect((res) => {
+          assert.equal((res.text.match(/representative.mp3/g) || []).length, 2,
+            'returns 2 representatives');
         })
         .end(done);
     });


### PR DESCRIPTION
Some zip codes map to multiple representatives.  The Civil Services API returns one representative maximum per zip code.  

This is a temporary workaround wherein we construct our own zip --> representative lookup table.  It can be reversed once the Civil Services API is updated to return potentially multiple representatives.